### PR TITLE
Fix Initial Game Over Loss Sound

### DIFF
--- a/source/meta/state/PlayState.hx
+++ b/source/meta/state/PlayState.hx
@@ -672,14 +672,11 @@ class PlayState extends MusicBeatState
 
 				resetMusic();
 
-				new FlxTimer().start(0.1, function(soundTime:FlxTimer)
-				{
-					FlxG.sound.play(Paths.sound('fnf_loss_sfx' + GameOverSubstate.stageSuffix));
-				});
-
 				openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
-				// discord stuffs should go here
+				FlxG.sound.play(Paths.sound(GameOverSubState.deathSound));
+
+				Discord.changePresence("Game Over - " + songDetails, detailsSub, iconRPC);
 			}
 
 			// spawn in the notes from the array

--- a/source/meta/state/PlayState.hx
+++ b/source/meta/state/PlayState.hx
@@ -674,7 +674,7 @@ class PlayState extends MusicBeatState
 
 				openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
-				FlxG.sound.play(Paths.sound(GameOverSubState.deathSound));
+				FlxG.sound.play(Paths.sound('fnf_loss_sfx' + GameOverSubstate.stageSuffix));
 
 				Discord.changePresence("Game Over - " + songDetails, detailsSub, iconRPC);
 			}

--- a/source/meta/state/PlayState.hx
+++ b/source/meta/state/PlayState.hx
@@ -674,7 +674,7 @@ class PlayState extends MusicBeatState
 
 				new FlxTimer().start(0.1, function(soundTime:FlxTimer)
 				{
-					FlxG.sound.play(Paths.sound('fnf_loss_sfx'));
+					FlxG.sound.play(Paths.sound('fnf_loss_sfx' + GameOverSubstate.stageSuffix));
 				});
 
 				openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));

--- a/source/meta/state/PlayState.hx
+++ b/source/meta/state/PlayState.hx
@@ -672,6 +672,11 @@ class PlayState extends MusicBeatState
 
 				resetMusic();
 
+				new FlxTimer().start(0.1, function(soundTime:FlxTimer)
+				{
+					FlxG.sound.play(Paths.sound('fnf_loss_sfx'));
+				});
+
 				openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
 				// discord stuffs should go here

--- a/source/meta/subState/GameOverSubstate.hx
+++ b/source/meta/subState/GameOverSubstate.hx
@@ -47,7 +47,6 @@ class GameOverSubstate extends MusicBeatSubState
 		camFollow = new FlxObject(bf.getGraphicMidpoint().x + 20, bf.getGraphicMidpoint().y - 40, 1, 1);
 		add(camFollow);
 
-		FlxG.sound.play(Paths.sound('fnf_loss_sfx' + stageSuffix));
 		Conductor.changeBPM(100);
 
 		// FlxG.camera.followLerp = 1;

--- a/source/meta/subState/GameOverSubstate.hx
+++ b/source/meta/subState/GameOverSubstate.hx
@@ -17,7 +17,7 @@ class GameOverSubstate extends MusicBeatSubState
 	//
 	var bf:Boyfriend;
 	var camFollow:FlxObject;
-	var stageSuffix:String = "";
+	public static var stageSuffix:String = "";
 
 	public function new(x:Float, y:Float)
 	{


### PR DESCRIPTION
there's an issue in which the game over screen can have either delayed, or muted sound for the "fnf_loss_sfx" sound, this PR fixes it by playing it on playstate rather than GameOverSubstate